### PR TITLE
style: 폰트, 컬러 변수 지정

### DIFF
--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,5 +1,4 @@
 @mixin typo_28_bold {
-	font-family: Pretendard;
 	font-size: 2.8rem;
 	font-style: normal;
 	font-weight: 700;
@@ -7,7 +6,6 @@
 	letter-spacing: -0.028rem;
 }
 @mixin typo_24_bold {
-	font-family: Pretendard;
 	font-size: 2.4rem;
 	font-style: normal;
 	font-weight: 700;
@@ -15,7 +13,6 @@
 	letter-spacing: -0.024rem;
 }
 @mixin typo_24_regular {
-	font-family: Pretendard;
 	font-size: 2.4rem;
 	font-style: normal;
 	font-weight: 400;
@@ -23,7 +20,6 @@
 	letter-spacing: -0.024rem;
 }
 @mixin typo_20_bold {
-	font-family: Pretendard;
 	font-size: 2rem;
 	font-style: normal;
 	font-weight: 700;
@@ -31,7 +27,6 @@
 	letter-spacing: -0.02rem;
 }
 @mixin typo_20_regular {
-	font-family: Pretendard;
 	font-size: 2rem;
 	font-style: normal;
 	font-weight: 400;
@@ -39,7 +34,6 @@
 	letter-spacing: -0.02rem;
 }
 @mixin typo_18_bold {
-	font-family: Pretendard;
 	font-size: 1.8rem;
 	font-style: normal;
 	font-weight: 700;
@@ -47,7 +41,6 @@
 	letter-spacing: -0.018rem;
 }
 @mixin typo_18_regular {
-	font-family: Pretendard;
 	font-size: 1.8rem;
 	font-style: normal;
 	font-weight: 400;
@@ -55,7 +48,6 @@
 	letter-spacing: -0.018rem;
 }
 @mixin typo_16_bold {
-	font-family: Pretendard;
 	font-size: 1.6rem;
 	font-style: normal;
 	font-weight: 700;
@@ -63,7 +55,6 @@
 	letter-spacing: -0.016rem;
 }
 @mixin typo_16_regular {
-	font-family: Pretendard;
 	font-size: 1.6rem;
 	font-style: normal;
 	font-weight: 400;
@@ -71,7 +62,6 @@
 	letter-spacing: -0.016rem;
 }
 @mixin typo_15_bold {
-	font-family: Pretendard;
 	font-size: 1.5rem;
 	font-style: normal;
 	font-weight: 700;
@@ -79,7 +69,6 @@
 	letter-spacing: -0.015rem;
 }
 @mixin typo_15_regular {
-	font-family: Pretendard;
 	font-size: 1.5rem;
 	font-style: normal;
 	font-weight: 400;
@@ -87,7 +76,6 @@
 	letter-spacing: -0.015rem;
 }
 @mixin typo_14_bold {
-	font-family: Pretendard;
 	font-size: 1.4rem;
 	font-style: normal;
 	font-weight: 700;
@@ -95,7 +83,6 @@
 	letter-spacing: -0.007rem;
 }
 @mixin typo_14_regular {
-	font-family: Pretendard;
 	font-size: 1.4rem;
 	font-style: normal;
 	font-weight: 400;
@@ -103,7 +90,6 @@
 	letter-spacing: -0.007rem;
 }
 @mixin typo_12_regular {
-	font-family: Pretendard;
 	font-size: 1.2rem;
 	font-style: normal;
 	font-weight: 400;

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,5 +1,159 @@
 @layer typography {
+	@mixin _28_bold {
+		font-family: Pretendard;
+		font-size: 28rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 42rem;
+		letter-spacing: -0.28rem;
+	}
+	@mixin _24_bold {
+		font-family: Pretendard;
+		font-size: 24rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 36rem;
+		letter-spacing: -0.24rem;
+	}
+	@mixin _24_regular {
+		font-family: Pretendard;
+		font-size: 24rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 36rem;
+		letter-spacing: -0.24rem;
+	}
+	@mixin _20_bold {
+		font-family: Pretendard;
+		font-size: 20rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 30rem;
+		letter-spacing: -0.2rem;
+	}
+	@mixin _20_regular {
+		font-family: Pretendard;
+		font-size: 20rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 30rem;
+		letter-spacing: -0.2rem;
+	}
+	@mixin _18_bold {
+		font-family: Pretendard;
+		font-size: 18rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 28rem;
+		letter-spacing: -0.18rem;
+	}
+	@mixin _18_regular {
+		font-family: Pretendard;
+		font-size: 18rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 28rem;
+		letter-spacing: -0.18rem;
+	}
+	@mixin _16_bold {
+		font-family: Pretendard;
+		font-size: 16rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 26rem;
+		letter-spacing: -0.16rem;
+	}
+	@mixin _16_regular {
+		font-family: Pretendard;
+		font-size: 16rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 26rem;
+		letter-spacing: -0.16rem;
+	}
+	@mixin _15_bold {
+		font-family: Pretendard;
+		font-size: 15rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 22rem;
+		letter-spacing: -0.15rem;
+	}
+	@mixin _15_regular {
+		font-family: Pretendard;
+		font-size: 15rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 22rem;
+		letter-spacing: -0.15rem;
+	}
+	@mixin _14_bold {
+		font-family: Pretendard;
+		font-size: 14rem;
+		font-style: normal;
+		font-weight: 700;
+		line-height: 20rem;
+		letter-spacing: -0.07rem;
+	}
+	@mixin _14_regular {
+		font-family: Pretendard;
+		font-size: 14rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20rem;
+		letter-spacing: -0.07rem;
+	}
+	@mixin _12_regular {
+		font-family: Pretendard;
+		font-size: 12rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 18rem;
+		letter-spacing: -0.06rem;
+	}
 }
 
 @layer color {
+	$purple-100: #f8f0ff;
+	$purple-200: #ecd9ff;
+	$purple-300: #dcb9ff;
+	$purple-400: #c894fd;
+	$purple-500: #ab57ff;
+	$purple-600: #9935ff;
+	$purple-700: #861dee;
+	$purple-800: #6e0ad1;
+	$purple-900: #5603a7;
+
+	$orange-100: #fff0d6;
+	$orange-200: #ffe2ad;
+	$orange-300: #ffc583;
+	$orange-400: #ffae65;
+	$orange-500: #ff8832;
+
+	$blue-100: #e2f5ff;
+	$blue-200: #b1e4ff;
+	$blue-300: #7cd2ff;
+	$blue-400: #34b9ff;
+	$blue-500: #00a2fe;
+
+	$green-100: #e4fbdc;
+	$green-200: #d0f5c3;
+	$green-300: #9be282;
+	$green-400: #60cf37;
+	$green-500: #2ba600;
+
+	$gray-100: #f6f6f6;
+	$gray-200: #eee;
+	$gray-300: #ccc;
+	$gray-400: #999;
+	$gray-500: #555;
+	$gray-600: #4a4a4a;
+	$gray-700: #3a3a3a;
+	$gray-800: #2b2b2b;
+	$gray-900: #181818;
+
+	$white: #fff;
+	$black: #000;
+	$error: #dc3a3a;
+	$surface: #f6f8ff;
 }

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -1,159 +1,155 @@
-@layer typography {
-	@mixin _28_bold {
-		font-family: Pretendard;
-		font-size: 28rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 42rem;
-		letter-spacing: -0.28rem;
-	}
-	@mixin _24_bold {
-		font-family: Pretendard;
-		font-size: 24rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 36rem;
-		letter-spacing: -0.24rem;
-	}
-	@mixin _24_regular {
-		font-family: Pretendard;
-		font-size: 24rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 36rem;
-		letter-spacing: -0.24rem;
-	}
-	@mixin _20_bold {
-		font-family: Pretendard;
-		font-size: 20rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 30rem;
-		letter-spacing: -0.2rem;
-	}
-	@mixin _20_regular {
-		font-family: Pretendard;
-		font-size: 20rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 30rem;
-		letter-spacing: -0.2rem;
-	}
-	@mixin _18_bold {
-		font-family: Pretendard;
-		font-size: 18rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 28rem;
-		letter-spacing: -0.18rem;
-	}
-	@mixin _18_regular {
-		font-family: Pretendard;
-		font-size: 18rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 28rem;
-		letter-spacing: -0.18rem;
-	}
-	@mixin _16_bold {
-		font-family: Pretendard;
-		font-size: 16rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 26rem;
-		letter-spacing: -0.16rem;
-	}
-	@mixin _16_regular {
-		font-family: Pretendard;
-		font-size: 16rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 26rem;
-		letter-spacing: -0.16rem;
-	}
-	@mixin _15_bold {
-		font-family: Pretendard;
-		font-size: 15rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 22rem;
-		letter-spacing: -0.15rem;
-	}
-	@mixin _15_regular {
-		font-family: Pretendard;
-		font-size: 15rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 22rem;
-		letter-spacing: -0.15rem;
-	}
-	@mixin _14_bold {
-		font-family: Pretendard;
-		font-size: 14rem;
-		font-style: normal;
-		font-weight: 700;
-		line-height: 20rem;
-		letter-spacing: -0.07rem;
-	}
-	@mixin _14_regular {
-		font-family: Pretendard;
-		font-size: 14rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 20rem;
-		letter-spacing: -0.07rem;
-	}
-	@mixin _12_regular {
-		font-family: Pretendard;
-		font-size: 12rem;
-		font-style: normal;
-		font-weight: 400;
-		line-height: 18rem;
-		letter-spacing: -0.06rem;
-	}
+@mixin typo_28_bold {
+	font-family: Pretendard;
+	font-size: 2.8rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 4.2rem;
+	letter-spacing: -0.028rem;
+}
+@mixin typo_24_bold {
+	font-family: Pretendard;
+	font-size: 2.4rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 3.6rem;
+	letter-spacing: -0.024rem;
+}
+@mixin typo_24_regular {
+	font-family: Pretendard;
+	font-size: 2.4rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 3.6rem;
+	letter-spacing: -0.024rem;
+}
+@mixin typo_20_bold {
+	font-family: Pretendard;
+	font-size: 2rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 3rem;
+	letter-spacing: -0.02rem;
+}
+@mixin typo_20_regular {
+	font-family: Pretendard;
+	font-size: 2rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 3rem;
+	letter-spacing: -0.02rem;
+}
+@mixin typo_18_bold {
+	font-family: Pretendard;
+	font-size: 1.8rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 2.8rem;
+	letter-spacing: -0.018rem;
+}
+@mixin typo_18_regular {
+	font-family: Pretendard;
+	font-size: 1.8rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 2.8rem;
+	letter-spacing: -0.018rem;
+}
+@mixin typo_16_bold {
+	font-family: Pretendard;
+	font-size: 1.6rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 2.6rem;
+	letter-spacing: -0.016rem;
+}
+@mixin typo_16_regular {
+	font-family: Pretendard;
+	font-size: 1.6rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 2.6rem;
+	letter-spacing: -0.016rem;
+}
+@mixin typo_15_bold {
+	font-family: Pretendard;
+	font-size: 1.5rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 2.2rem;
+	letter-spacing: -0.015rem;
+}
+@mixin typo_15_regular {
+	font-family: Pretendard;
+	font-size: 1.5rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 2.2rem;
+	letter-spacing: -0.015rem;
+}
+@mixin typo_14_bold {
+	font-family: Pretendard;
+	font-size: 1.4rem;
+	font-style: normal;
+	font-weight: 700;
+	line-height: 2rem;
+	letter-spacing: -0.007rem;
+}
+@mixin typo_14_regular {
+	font-family: Pretendard;
+	font-size: 1.4rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 2rem;
+	letter-spacing: -0.007rem;
+}
+@mixin typo_12_regular {
+	font-family: Pretendard;
+	font-size: 1.2rem;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 1.8rem;
+	letter-spacing: -0.006rem;
 }
 
-@layer color {
-	$purple-100: #f8f0ff;
-	$purple-200: #ecd9ff;
-	$purple-300: #dcb9ff;
-	$purple-400: #c894fd;
-	$purple-500: #ab57ff;
-	$purple-600: #9935ff;
-	$purple-700: #861dee;
-	$purple-800: #6e0ad1;
-	$purple-900: #5603a7;
+$color_purple_100: #f8f0ff;
+$color_purple_200: #ecd9ff;
+$color_purple_300: #dcb9ff;
+$color_purple_400: #c894fd;
+$color_purple_500: #ab57ff;
+$color_purple_600: #9935ff;
+$color_purple_700: #861dee;
+$color_purple_800: #6e0ad1;
+$color_purple_900: #5603a7;
 
-	$orange-100: #fff0d6;
-	$orange-200: #ffe2ad;
-	$orange-300: #ffc583;
-	$orange-400: #ffae65;
-	$orange-500: #ff8832;
+$color_orange_100: #fff0d6;
+$color_orange_200: #ffe2ad;
+$color_orange_300: #ffc583;
+$color_orange_400: #ffae65;
+$color_orange_500: #ff8832;
 
-	$blue-100: #e2f5ff;
-	$blue-200: #b1e4ff;
-	$blue-300: #7cd2ff;
-	$blue-400: #34b9ff;
-	$blue-500: #00a2fe;
+$color_blue_100: #e2f5ff;
+$color_blue_200: #b1e4ff;
+$color_blue_300: #7cd2ff;
+$color_blue_400: #34b9ff;
+$color_blue_500: #00a2fe;
 
-	$green-100: #e4fbdc;
-	$green-200: #d0f5c3;
-	$green-300: #9be282;
-	$green-400: #60cf37;
-	$green-500: #2ba600;
+$color_green_100: #e4fbdc;
+$color_green_200: #d0f5c3;
+$color_green_300: #9be282;
+$color_green_400: #60cf37;
+$color_green_500: #2ba600;
 
-	$gray-100: #f6f6f6;
-	$gray-200: #eee;
-	$gray-300: #ccc;
-	$gray-400: #999;
-	$gray-500: #555;
-	$gray-600: #4a4a4a;
-	$gray-700: #3a3a3a;
-	$gray-800: #2b2b2b;
-	$gray-900: #181818;
+$color_gray_100: #f6f6f6;
+$color_gray_200: #eee;
+$color_gray_300: #ccc;
+$color_gray_400: #999;
+$color_gray_500: #555;
+$color_gray_600: #4a4a4a;
+$color_gray_700: #3a3a3a;
+$color_gray_800: #2b2b2b;
+$color_gray_900: #181818;
 
-	$white: #fff;
-	$black: #000;
-	$error: #dc3a3a;
-	$surface: #f6f8ff;
-}
+$white: #fff;
+$black: #000;
+$error: #dc3a3a;
+$surface: #f6f8ff;

--- a/src/pages/home/HomePage.module.scss
+++ b/src/pages/home/HomePage.module.scss
@@ -1,3 +1,3 @@
 .text_28 {
-	font-size: 28px;
+	@include typo_28_bold;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,4 +10,11 @@ export default defineConfig({
 			'@': resolve(__dirname, './src'),
 		},
 	},
+	css: {
+		preprocessorOptions: {
+			scss: {
+				additionalData: `@use "@/assets/variables.scss" as *;`,
+			},
+		},
+	},
 });


### PR DESCRIPTION
## 어떤 변경인지 
- [ ] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [x] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명

### 이슈 번호
>  예) .../Codeit-Rolling-11-Letsgo/Rolling/issues/**7** 
https://github.com/Codeit-Rolling-11-Letsgo/Rolling/issues/1


### 주요 변경 사항 
- variables.scss 파일에 프로젝트에서 사용할 폰트, 컬러에 대한 변수를 지정해두었습니다


### 어떻게 동작하는지
```
.className {
  @include typo_28_bold; 
}
```
```
.className {
  background-color: $color_purple_100; 
}
```
와 같이 사용합니다.
```
css: {
	preprocessorOptions: {
		scss: {
			additionalData: `@use "@/assets/variables.scss" as *;`,
		},
	},
},
```
vite.config 파일에 위 명령을 추가하여 해당 mixin 및 변수를 사용할때 별도의 import/use 문을 사용하지 않아도 됩니다!

### To Reviewers
- 폰트 크기에 따라서 letter spacing, line-height의 값이 다르게 설정되어있어 mixin 문법을 사용하였습니다 
- rem 단위로 통일하였습니다