### PR TITLE
feat: 이모지바 레이아웃 구현

### DIFF
--- a/src/components/HeaderService/HeaderService.jsx
+++ b/src/components/HeaderService/HeaderService.jsx
@@ -1,0 +1,11 @@
+import styles from './HeaderService.module.scss';
+
+export default function HeaderService() {
+	//api 요청 여기서 할 예정
+	return (
+		<div className={styles.layout}>
+			<div className={styles.toSomeone}>To.~~</div>
+			<div className={styles.reactionByEmoji}>반응 모음</div>
+		</div>
+	);
+}

--- a/src/components/HeaderService/HeaderService.jsx
+++ b/src/components/HeaderService/HeaderService.jsx
@@ -4,8 +4,8 @@ export default function HeaderService() {
 	//api 요청 여기서 할 예정
 	return (
 		<div className={styles.layout}>
-			<div className={styles.toSomeone}>To.~~</div>
-			<div className={styles.reactionByEmoji}>반응 모음</div>
+			<h2 className={styles.title}>To.~~</h2>
+			<div className={styles.service}>반응 모음</div>
 		</div>
 	);
 }

--- a/src/components/HeaderService/HeaderService.module.scss
+++ b/src/components/HeaderService/HeaderService.module.scss
@@ -1,0 +1,37 @@
+.toSomeone {
+	grid-area: toSomeone;
+}
+
+.reactionByEmoji {
+	grid-area: emoji;
+}
+
+.layout {
+	@include typo_28_bold;
+	display: grid;
+	grid-template-areas: 'toSomeone emoji';
+	justify-content: space-between;
+	max-width: 124.8rem;
+	padding-inline: 2.4rem;
+	margin-inline: auto;
+	align-items: center;
+	height: 6.8rem;
+	@media (max-width: 767px) {
+		@include typo_18_bold;
+		padding-inline: 2rem;
+		height: auto;
+		grid-template-areas:
+			'toSomeone'
+			'emoji';
+	}
+}
+
+.toSomeone,
+.reactionByEmoji {
+	display: flex;
+	align-items: center;
+	height: 100%;
+	@media (max-width: 767px) {
+		height: 5.2rem;
+	}
+}

--- a/src/components/HeaderService/HeaderService.module.scss
+++ b/src/components/HeaderService/HeaderService.module.scss
@@ -1,15 +1,15 @@
-.toSomeone {
-	grid-area: toSomeone;
+.title {
+	grid-area: title;
 }
 
-.reactionByEmoji {
-	grid-area: emoji;
+.service {
+	grid-area: service;
 }
 
 .layout {
 	@include typo_28_bold;
 	display: grid;
-	grid-template-areas: 'toSomeone emoji';
+	grid-template-areas: 'title service';
 	justify-content: space-between;
 	max-width: 124.8rem;
 	padding-inline: 2.4rem;
@@ -21,13 +21,13 @@
 		padding-inline: 2rem;
 		height: auto;
 		grid-template-areas:
-			'toSomeone'
-			'emoji';
+			'title'
+			'service';
 	}
 }
 
-.toSomeone,
-.reactionByEmoji {
+.title,
+.service {
 	display: flex;
 	align-items: center;
 	height: 100%;


### PR DESCRIPTION
## 어떤 변경인지 
- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
HeaderService 레이아웃을 구현했습니다 
(이모지바라고 불러왔는데 시안을 보니 명칭이 따로 있더라구요. 앞으로는 헤더 서비스라고 부르겠습니다)
아래 이미지는 순서대로 pc, 태블릿, 모바일인데 
![image](https://github.com/Codeit-Rolling-11-Letsgo/Rolling/assets/148179726/fce82771-c381-4eb7-b446-2e63f7300735)
![image](https://github.com/Codeit-Rolling-11-Letsgo/Rolling/assets/148179726/97aca528-bf1b-435c-9203-9e6cabf45b56)
![image](https://github.com/Codeit-Rolling-11-Letsgo/Rolling/assets/148179726/738b60ff-4550-4328-b7d6-48872f19afb6)
반응형 구현은 나중일이라고 생각하려고 해도 모바일 시안까지 미리 생각해두는게 편해서 데이터 페칭 없이 일단 grid로 모바일까지의 레이아웃을 구현했습니다!
HeaderService 컴포넌트 내의 두 div는 추후 컴포넌트로 교체할 예정입니다.

### 이슈 번호
>  예) .../Codeit-Rolling-11-Letsgo/Rolling/issues/**7** 
https://github.com/Codeit-Rolling-11-Letsgo/Rolling/issues/24

### To Reviewers
767px을 breakpoint로 잡아서 미디어 쿼리를 썼는데 미디어 쿼리 구문에서 767px를 76.7rem으로 단위만 바꾸면 화면을 줄이면서 봤을 때 모바일로 바뀌는 시점이 좀 빨라지는 이슈가 있습니다.
단위만 바꿨는데 왜 이러나 싶어서,, 팀웝분들의 의견이 필요합니다