### PR TITLE
Feat: 캐러셀 크기에 따라 넘어가는 아이템 수 변경

### DIFF
--- a/src/components/common/carousel/Carousel.jsx
+++ b/src/components/common/carousel/Carousel.jsx
@@ -1,25 +1,22 @@
 import clsx from 'clsx';
-import { useRef, useState } from 'react';
+import { forwardRef, useRef, useState } from 'react';
 
 import styles from '@/components/common/carousel/Carousel.module.scss';
 import Icon from '@/components/common/icon/Icon';
-import { detectMobile } from '@/utils/util';
+import { detectTouchScreen } from '@/utils/util';
 
 /**
  *
  * @param {{items: {id: number | string, item: React.ReactNode}[], swipeCount: number, onClickPrev: () => {}, onClickNext: () => {}}} props
  * @returns
  */
-export default function Carousel({
-	itemList,
-	swipeCount = 1,
-	onClickPrev = () => {},
-	onClickNext = () => {},
-}) {
+const Carousel = forwardRef(function Carousel(
+	{ itemList, swipeCount = 1, onClickPrev = () => {}, onClickNext = () => {} },
+	ref,
+) {
 	const [currentIdx, setCurrentIdx] = useState(0);
-	const swipeCountRef = useRef(swipeCount);
 	const itemMapRef = useRef(null);
-	const isMobile = detectMobile();
+	const isTouchScreen = detectTouchScreen();
 
 	const scrollToId = (itemId) => {
 		const map = getMap();
@@ -39,23 +36,28 @@ export default function Carousel({
 	};
 
 	const handlePrevClick = () => {
-		scrollToId(itemList.at(currentIdx - swipeCountRef.current).id);
-		setCurrentIdx((ci) => ci - swipeCountRef.current);
+		const prevIdx = Math.max(currentIdx - swipeCount, 0);
+		scrollToId(itemList.at(prevIdx).id);
+		setCurrentIdx(prevIdx);
 		onClickPrev();
 	};
 
 	const handleNextClick = () => {
-		scrollToId(itemList.at(currentIdx + swipeCountRef.current).id);
-		setCurrentIdx((ci) => ci + swipeCountRef.current);
+		const nextIdx = Math.min(
+			currentIdx + swipeCount,
+			itemList.length - swipeCount,
+		);
+		scrollToId(itemList.at(nextIdx).id);
+		setCurrentIdx(nextIdx);
 		onClickNext();
 	};
 
-	const isFirst = currentIdx === 0;
-	const isEnd = currentIdx + swipeCountRef.current === itemList.length;
+	const isFirst = currentIdx <= 0;
+	const isEnd = currentIdx + swipeCount >= itemList.length;
 
 	return (
-		<div className={styles.container}>
-			{isMobile || isFirst ? null : (
+		<div className={styles.container} ref={ref}>
+			{isTouchScreen || isFirst ? null : (
 				<button
 					onClick={handlePrevClick}
 					className={clsx(styles.carousel_button, styles.prev)}
@@ -63,7 +65,7 @@ export default function Carousel({
 					<Icon name='arrowLeft' className={styles.left_arrow} />
 				</button>
 			)}
-			{isMobile || isEnd ? null : (
+			{isTouchScreen || isEnd ? null : (
 				<button
 					onClick={handleNextClick}
 					className={clsx(styles.carousel_button, styles.next)}
@@ -91,4 +93,6 @@ export default function Carousel({
 			</ol>
 		</div>
 	);
-}
+});
+
+export default Carousel;

--- a/src/components/common/carousel/Carousel.jsx
+++ b/src/components/common/carousel/Carousel.jsx
@@ -53,7 +53,7 @@ const Carousel = forwardRef(function Carousel(
 	};
 
 	const isFirst = currentIdx <= 0;
-	const isEnd = currentIdx + swipeCount >= itemList.length;
+	const isEnd = currentIdx + swipeCount >= itemList.length - swipeCount;
 
 	return (
 		<div className={styles.container} ref={ref}>

--- a/src/components/list/RecipientCardList.jsx
+++ b/src/components/list/RecipientCardList.jsx
@@ -1,12 +1,27 @@
+import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import Carousel from '@/components/common/carousel/Carousel';
 import RecipientCard from '@/components/list/RecipientCard';
 import { PATH_POST } from '@/constants/routes';
+import useDOMWidth from '@/hooks/common/useDOMWidth';
 
 export default function RecipientCardList({ recipientList }) {
+	const DEFAULT_CAROUSEL_WIDTH = 1200;
+	const CARD_WIDTH = 275;
+	const GAP = 20;
+	const carouselRef = useRef(null);
+	const carouselWidth = useDOMWidth(carouselRef, { debounce: 10 });
+	console.log(carouselWidth);
+
+	let swipeCount = 4;
+	if (carouselWidth <= DEFAULT_CAROUSEL_WIDTH - CARD_WIDTH / 2) swipeCount = 3;
+	if (carouselWidth <= DEFAULT_CAROUSEL_WIDTH - CARD_WIDTH * 1.5 - GAP)
+		swipeCount = 2;
+
 	return (
 		<Carousel
+			ref={carouselRef}
 			itemList={recipientList.map((recipient) => ({
 				id: recipient.id,
 				item: (
@@ -15,7 +30,7 @@ export default function RecipientCardList({ recipientList }) {
 					</Link>
 				),
 			}))}
-			swipeCount={4}
+			swipeCount={swipeCount}
 		/>
 	);
 }

--- a/src/components/list/RecipientCardList.jsx
+++ b/src/components/list/RecipientCardList.jsx
@@ -12,7 +12,6 @@ export default function RecipientCardList({ recipientList }) {
 	const GAP = 20;
 	const carouselRef = useRef(null);
 	const carouselWidth = useDOMWidth(carouselRef, { debounce: 10 });
-	console.log(carouselWidth);
 
 	let swipeCount = 4;
 	if (carouselWidth <= DEFAULT_CAROUSEL_WIDTH - CARD_WIDTH / 2) swipeCount = 3;

--- a/src/hooks/common/useDOMWidth.js
+++ b/src/hooks/common/useDOMWidth.js
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from 'react';
+
+export default function useDOMWidth(targetRef, { debounce = 1 }) {
+	const getSnapshot = () => {
+		const width = targetRef.current?.clientWidth;
+
+		return width ? Math.floor(width / debounce) * debounce : 1;
+	};
+	const subscribe = (callback) => {
+		if (!targetRef.current) return;
+
+		const observer = new ResizeObserver(callback);
+		observer.observe(targetRef.current);
+
+		return () => observer.disconnect();
+	};
+	return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -8,7 +8,7 @@ export const take = (iter, count) => {
 	return res;
 };
 
-export const detectMobile = () => {
+export const detectTouchScreen = () => {
 	try {
 		document.createEvent('TouchEvent');
 		return true;


### PR DESCRIPTION
## 어떤 변경인지 
- [x] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
캐러셀 크기에 따라 넘어가는 Recipient 카드 개수가 달라집니다.

### 이슈 번호
>  예) .../Codeit-Rolling-11-Letsgo/Rolling/issues/**7** 
https://github.com/Codeit-Rolling-11-Letsgo/Rolling/issues/65

### 주요 변경 사항
- useDOMWidth 훅 추가
- 카드의 반을 가릴 시 RecipientCardList의 넘어가는 개수가 1 줄어듭니다.

### 어떻게 동작하는지

### To Reviewers
