### PR TITLE
fix: Toast 여러번 클릭해도 동일한 timer 공유하는 버그 수정

### DIFF
--- a/src/components/post/header-service/ShareButton.jsx
+++ b/src/components/post/header-service/ShareButton.jsx
@@ -12,6 +12,7 @@ export default function ShareButton({ shareInfo }) {
 
 	const [isPickerOpened, setIsPickerOpened] = useState(false);
 	const [isToastVisible, setIsToastVisible] = useState(false);
+	const [toastTimer, setToastTimer] = useState(null);
 	const shareOptionPickerRef = useRef(null);
 
 	const handlePickerToggle = () => {
@@ -40,13 +41,16 @@ export default function ShareButton({ shareInfo }) {
 
 	const handleCopyUrl = (e) => {
 		const currentUrl = window.location.href;
+		if (toastTimer) clearTimeout(toastTimer);
+
 		navigator.clipboard
 			.writeText(currentUrl)
 			.then(() => {
 				setIsToastVisible(true);
-				setTimeout(() => {
+				const newTimer = setTimeout(() => {
 					setIsToastVisible(false);
 				}, 5000);
+				setToastTimer(newTimer);
 			})
 			.catch((error) => {
 				throw new error(error);


### PR DESCRIPTION
## 어떤 변경인지 
- [ ] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [ ] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [x] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
5초 안에 토스트를 두 번 열었을 때 두번째 열린 토스트는 첫번째 토스트의 타이머가 적용되어서 5초가 안 되어 사라지는 버그가 있었는데 
clearTimeout을 통해 매 클릭마다 새 타이머를 불러오도록 변경했습니다
timerId를 코드 블록 바깥에서 써야해서 state를 사용했습니다

### 이슈 번호
>  예) .../Codeit-Rolling-11-Letsgo/Rolling/issues/**7** 
https://github.com/Codeit-Rolling-11-Letsgo/Rolling/issues/93

### 주요 변경 사항 

### 어떻게 동작하는지

### To Reviewers
