### PR TITLE
Refactor: post id 페이지, post 카드 리팩터링

### DIFF
--- a/src/components/post/PostCard.jsx
+++ b/src/components/post/PostCard.jsx
@@ -1,6 +1,5 @@
 import { motion } from 'framer-motion';
 
-import { deleteMessage } from '@/apis/post/postAPI';
 import Button from '@/components/common/button/Button';
 import Card from '@/components/common/card/Card';
 import Icon from '@/components/common/icon/Icon';
@@ -10,7 +9,7 @@ import { fontNamesEng } from '@/constants/fontNames';
 import { formatDate } from '@/utils/dateUtils';
 import { hoverCard } from '@/utils/framerAnimation';
 
-function PostCard({ message, openModal, isEdit, reload }) {
+function PostCard({ message, openModal, isEdit, deleteMessage }) {
 	const {
 		profileImageURL,
 		sender,
@@ -23,13 +22,7 @@ function PostCard({ message, openModal, isEdit, reload }) {
 
 	const handleClickDelete = async (e) => {
 		e.stopPropagation();
-		const result = await deleteMessage(id);
-		if (!result) {
-			// TODO: 삭제 실패 toast
-			return;
-		}
-
-		await reload();
+		deleteMessage(id);
 	};
 
 	return (

--- a/src/components/post/PostModal.jsx
+++ b/src/components/post/PostModal.jsx
@@ -17,7 +17,8 @@ const PostModal = () => {
 	useEffect(() => {
 		if (isModalOpen) {
 			dialogRef.current.showModal();
-		} else if (dialogRef.current.open) {
+		}
+		if (!isModalOpen) {
 			dialogRef.current.close();
 		}
 	}, [isModalOpen]);

--- a/src/pages/post/PostIdPage.jsx
+++ b/src/pages/post/PostIdPage.jsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
 
-import { deleteRecipient, getMessageList } from '@/apis/post/postAPI';
+import {
+	deleteMessage,
+	deleteRecipient,
+	getMessageList,
+} from '@/apis/post/postAPI';
 import Button from '@/components/common/button/Button';
 import NewMessageCTA from '@/components/post/NewMessageCTA';
 import PostCard from '@/components/post/PostCard';
@@ -17,6 +21,7 @@ export default function PostIdPage() {
 	const navigate = useNavigate();
 	const { recipientId, messageListInfo, recipientInfo } = useLoaderData();
 	const { isModalOpen, openModal } = useModalContext();
+	console.log(isModalOpen);
 
 	const isEdit = pathname.includes('edit');
 
@@ -57,6 +62,16 @@ export default function PostIdPage() {
 		setCurrentMessageListInfo(newMessageListInfo);
 		setCurrentMessageList(newMessageListInfo.results);
 		setIsLoading(false);
+	};
+
+	const handleClickDeleteMessage = async (id) => {
+		const result = await deleteMessage(id);
+		if (!result) {
+			// TODO: 삭제 실패 toast
+			return;
+		}
+
+		await reload();
 	};
 
 	const handleClickDelete = async () => {
@@ -101,7 +116,7 @@ export default function PostIdPage() {
 						message={message}
 						openModal={openModal}
 						isEdit={isEdit}
-						reload={reload}
+						deleteMessage={handleClickDeleteMessage}
 					></PostCard>
 				))}
 


### PR DESCRIPTION
모달 닫는 조건을 여는 조건과 통일

## 어떤 변경인지 
- [ ] Feat: 기능 변경, 기능 추가
- [ ] Docs: 문서 작업
- [x] Refactor: 기능 변경 없이 코드 수정
- [ ] Style: 디자인
- [ ] Fix: 버그 수정
- [ ] Test: 테스트 코드 작성

## 설명
post card 컴포넌트에서 삭제 api를 직접 호출하지 않고 post id page에서 호출하도록 변경했습니다.
모달은 켜지는 조건과 꺼지는 조건을 동일하게 맞춰 헷깔리는 상황을 방지했습니다.

### 이슈 번호
https://github.com/Codeit-Rolling-11-Letsgo/Rolling/issues/125


